### PR TITLE
Fix navigation to implementation with property inference for extension methods

### DIFF
--- a/src/main/java/manifold/ij/extensions/ManResolveCache.java
+++ b/src/main/java/manifold/ij/extensions/ManResolveCache.java
@@ -425,7 +425,7 @@ public class ManResolveCache extends ResolveCache
     PsiClass psiClass = refMethod.getContainingClass();
     ManLightMethodBuilder method = manPsiElemFactory
       .createLightMethod( manModule, psiClass.getManager(), methodName )
-      .withContainingClass( psiClass );
+      .withContainingClass( refMethod.getContainingClass() );
     method.withNavigationElement( refMethod.getNavigationElement() );
     method.withMethodReturnType( handleType( refMethod.getReturnType(), ref, refMethod ) );
     copyAnnotations( refMethod, method );

--- a/src/main/java/manifold/ij/extensions/ManResolveCache.java
+++ b/src/main/java/manifold/ij/extensions/ManResolveCache.java
@@ -425,7 +425,7 @@ public class ManResolveCache extends ResolveCache
     PsiClass psiClass = refMethod.getContainingClass();
     ManLightMethodBuilder method = manPsiElemFactory
       .createLightMethod( manModule, psiClass.getManager(), methodName )
-      .withContainingClass( refMethod.getContainingClass() );
+      .withContainingClass( psiClass );
     method.withNavigationElement( refMethod.getNavigationElement() );
     method.withMethodReturnType( handleType( refMethod.getReturnType(), ref, refMethod ) );
     copyAnnotations( refMethod, method );

--- a/src/main/java/manifold/ij/util/ManPsiGenerationUtil.java
+++ b/src/main/java/manifold/ij/util/ManPsiGenerationUtil.java
@@ -84,7 +84,7 @@ public class ManPsiGenerationUtil
       String methodName = refMethod.getName();
       ManExtensionMethodBuilder method = manPsiElemFactory.createExtensionMethodMethod( manModule, psiClass.getManager(), methodName, navMethod )
         .withMethodReturnType( refMethod.getReturnType() )
-        .withContainingClass( psiClass );
+        .withContainingClass( navMethod.getContainingClass() );
 
       method.setConstructor( refMethod.isConstructor() || isConstructor );
       


### PR DESCRIPTION
# Description

When navigating to the implementation of an extension method when property inference is used doesn't navigate to the extension method, but rather to the extended class, which doesn't contain the extension method.

# Example:

```java
// Path extension
public static String getExtension(@This Path path) {
    return StringUtils.substringAfterLast(path.getFileName().toString(), ".");
}

Path p = ...;
String extension = p.getExtension(); // Navigates to the correct implementation
String extension = p.extension; // Does not navigate to the correct implementation
```

# Implemented Solution

When creating a `ManLightMethodBuilder`, the provided `psiClass` shouldn't be used as the containing class. Instead, the `containingClass` of the `navMethod` should be used. For non-extension methods, this is the same class. However, this isn't the same class for extension methods.

This PR fixes https://github.com/manifold-systems/manifold-ij/issues/85