### PR TITLE
Suppress `@NullMarked fields must be initialized` warning for abstract properties

### DIFF
--- a/src/main/java/manifold/ij/extensions/ManPropertiesHighlightInfoFilter.java
+++ b/src/main/java/manifold/ij/extensions/ManPropertiesHighlightInfoFilter.java
@@ -19,11 +19,14 @@
 
 package manifold.ij.extensions;
 
+import static manifold.ij.extensions.PropertyUtil.*;
+
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.daemon.impl.HighlightInfoFilter;
 import com.intellij.lang.java.JavaLanguage;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.light.LightRecordMember;
+import manifold.ext.props.rt.api.PropOption;
 import manifold.ext.props.rt.api.get;
 import manifold.ext.props.rt.api.set;
 import manifold.ext.props.rt.api.val;
@@ -35,7 +38,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
-
 
 /**
  * Suppress errors around properties that are not really errors
@@ -116,6 +118,11 @@ public class ManPropertiesHighlightInfoFilter implements HighlightInfoFilter
       return false;
     }
 
+    if( filterFieldMustBeInitializedForAbstractProperty( hi, parent ) )
+    {
+      return false;
+    }
+
     return true;
   }
 
@@ -165,6 +172,13 @@ public class ManPropertiesHighlightInfoFilter implements HighlightInfoFilter
     // @val fields are already final
     PsiField field = getPropFieldFromDecl( firstElem );
     return field != null && isReadOnly( field );
+  }
+
+  private boolean filterFieldMustBeInitializedForAbstractProperty( HighlightInfo hi, PsiElement parent )
+  {
+    return "@NullMarked fields must be initialized".equals(hi.getDescription()) &&
+      parent instanceof PsiField field &&
+      ( hasAbstractModifier( field ) || hasOption( field, PropOption.Abstract ) );
   }
 
   private boolean filterAbstractError( HighlightInfo hi, PsiElement firstElem )
@@ -245,6 +259,11 @@ public class ManPropertiesHighlightInfoFilter implements HighlightInfoFilter
       }
     }
     return false;
+  }
+
+  private boolean hasAbstractModifier( PsiField field )
+  {
+    return field.getModifierList() != null && field.getModifierList().hasModifierProperty( PsiModifier.ABSTRACT );
   }
 
   private boolean isVar( PsiField field )

--- a/src/main/java/manifold/ij/extensions/PropertyMaker.java
+++ b/src/main/java/manifold/ij/extensions/PropertyMaker.java
@@ -46,6 +46,7 @@ import java.util.*;
 
 import static java.lang.reflect.Modifier.*;
 import static manifold.ext.props.PropIssueMsg.*;
+import static manifold.ij.extensions.PropertyUtil.*;
 
 class PropertyMaker
 {
@@ -695,15 +696,6 @@ class PropertyMaker
       accessorAccess == 0 && propAccess == PRIVATE;
   }
 
-  private boolean hasOption( List<JvmAnnotationAttribute> args, PropOption option )
-  {
-    if( args == null )
-    {
-      return false;
-    }
-    return args.stream().anyMatch( e -> isOption( option, e ) );
-  }
-
   private PropOption getAccess( List<JvmAnnotationAttribute> args )
   {
     if( _psiClass.isInterface() )
@@ -741,19 +733,6 @@ class PropertyMaker
       return PRIVATE;
     }
     return publicDefault ? PUBLIC : 0;
-  }
-
-  private boolean isOption( PropOption option, JvmAnnotationAttribute e )
-  {
-    if( e instanceof PsiNameValuePair )
-    {
-      JvmAnnotationAttributeValue value = e.getAttributeValue();
-      if( value instanceof JvmAnnotationEnumFieldValue )
-      {
-        return Objects.equals( ((JvmAnnotationEnumFieldValue)value).getFieldName(), option.name() );
-      }
-    }
-    return false;
   }
 
   private boolean isAbstract()

--- a/src/main/java/manifold/ij/extensions/PropertyUtil.java
+++ b/src/main/java/manifold/ij/extensions/PropertyUtil.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  * Copyright (c) 2022 - Manifold Systems LLC
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package manifold.ij.extensions;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.intellij.lang.jvm.annotation.JvmAnnotationArrayValue;
+import com.intellij.lang.jvm.annotation.JvmAnnotationAttribute;
+import com.intellij.lang.jvm.annotation.JvmAnnotationAttributeValue;
+import com.intellij.lang.jvm.annotation.JvmAnnotationEnumFieldValue;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiNameValuePair;
+import manifold.ext.props.rt.api.PropOption;
+import manifold.ext.props.rt.api.get;
+import manifold.ext.props.rt.api.set;
+import manifold.ext.props.rt.api.val;
+import manifold.ext.props.rt.api.var;
+
+class PropertyUtil
+{
+
+  private PropertyUtil()
+  {
+    // Hide Utility Class Constructor
+  }
+
+  public static boolean hasOption( PsiField field, PropOption option )
+  {
+    for( Class<?> cls : List.of( var.class, val.class, get.class, set.class ) )
+    {
+      PsiAnnotation propAnno = field.getAnnotation( cls.getTypeName() );
+      if( propAnno != null && hasOption( propAnno.getAttributes(), option ) )
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean hasOption( List<JvmAnnotationAttribute> args, PropOption option )
+  {
+    if( args == null )
+    {
+      return false;
+    }
+    for( JvmAnnotationAttribute attr : args )
+    {
+      if( hasOption( attr, option ) )
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasOption( JvmAnnotationAttribute e, PropOption option )
+  {
+    return e instanceof PsiNameValuePair && hasOption( e.getAttributeValue(), option );
+  }
+
+  private static boolean hasOption( JvmAnnotationAttributeValue value, PropOption option )
+  {
+    if( value instanceof JvmAnnotationEnumFieldValue v )
+    {
+      return Objects.equals( v.getFieldName(), option.name() );
+    }
+    else if ( value instanceof JvmAnnotationArrayValue v )
+    {
+      for( JvmAnnotationAttributeValue val : v.getValues() )
+      {
+        if( hasOption( val, option) )
+        {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
# Description

When using JSpecify's `@NullMarked`, IntelliJ IDEA incorrectly reports that abstract properties must be initialized with the warning:  `@NullMarked fields must be initialized`.

However, abstract properties are not actual fields, they are abstract accessor methods that are meant to be implemented by subclasses. Since they do not represent concrete fields, requiring initialization is incorrect.

This results in a false positive warning and should be suppressed.

# Example:

```java
@NullMarked
public abstract class Test {
    @val abstract String foo; // @NullMarked fields must be initialized 
}
```

# Implementation note

Common code was extracted to a separate utility class `PropertyUtil`. It also includes a fix for the current code where multiple  `PropOption` values where not correctly handled (e.g. `@var({ Abstract, Protected })`)

This PR fixes https://github.com/manifold-systems/manifold-ij/issues/87