### PR TITLE
Fix scope issue causing false incompatible type error

### DIFF
--- a/src/main/java/manifold/ij/extensions/ManPropertiesAugmentProvider.java
+++ b/src/main/java/manifold/ij/extensions/ManPropertiesAugmentProvider.java
@@ -61,6 +61,15 @@ public class ManPropertiesAugmentProvider extends PsiAugmentProvider
   static final Key<CachedValue<List<PsiField>>> KEY_CACHED_PROP_FIELD_AUGMENTS = new Key<>( "KEY_CACHED_PROP_FIELD_AUGMENTS" );
   static final Key<CachedValue<List<PsiMethod>>> KEY_CACHED_PROP_METHOD_AUGMENTS = new Key<>( "KEY_CACHED_PROP_METHOD_AUGMENTS" );
 
+  public static List<PsiField> collectPropertyFieldAugments( @NotNull PsiClass psiClass )
+  {
+    if( !(psiClass instanceof PsiExtensibleClass) )
+    {
+      return Collections.emptyList();
+    }
+    return new ManPropertiesAugmentProvider().getAugments( psiClass, PsiField.class, null );
+  }
+
   @SuppressWarnings( "deprecation" )
   @NotNull
   public <E extends PsiElement> List<E> getAugments( @NotNull PsiElement element, @NotNull Class<E> cls )
@@ -271,7 +280,7 @@ public class ManPropertiesAugmentProvider extends PsiAugmentProvider
       if( psiClass != origin )
       {
         // force augments to load on fields, for the side effect of adding VAR_TAG etc. to existing fields
-        PsiAugmentProvider.collectAugments( psiClass, PsiField.class, null );
+        collectPropertyFieldAugments( psiClass );
       }
     }
     finally

--- a/src/main/java/manifold/ij/extensions/ManResolveCache.java
+++ b/src/main/java/manifold/ij/extensions/ManResolveCache.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
-import com.intellij.psi.augment.PsiAugmentProvider;
 import com.intellij.psi.impl.compiled.ClsClassImpl;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
 import com.intellij.psi.impl.source.tree.java.PsiMethodCallExpressionImpl;
@@ -345,7 +344,7 @@ public class ManResolveCache extends ResolveCache
     // limiting to ClsClassImpl for now, maybe source classes too someday if necessary
     if( psiClass instanceof ClsClassImpl )
     {
-      PsiAugmentProvider.collectAugments( psiClass, PsiField.class, null );
+      ManPropertiesAugmentProvider.collectPropertyFieldAugments( psiClass );
       return true;
     }
 

--- a/src/main/java/manifold/ij/extensions/ManResolveScopeProvider.java
+++ b/src/main/java/manifold/ij/extensions/ManResolveScopeProvider.java
@@ -90,7 +90,8 @@ public class ManResolveScopeProvider extends ResolveScopeEnlarger
       }
       else
       {
-        if( !scope.isSearchInModuleContent( module.getIjModule() ) )
+        // avoid redundant union when the module is already covered by current union scope
+        if( !unionScope.isSearchInModuleContent( module.getIjModule() ) )
         {
           unionScope = unionScope.union( scope );
         }

--- a/src/main/java/manifold/ij/extensions/ManResolveScopeProvider.java
+++ b/src/main/java/manifold/ij/extensions/ManResolveScopeProvider.java
@@ -19,6 +19,7 @@
 
 package manifold.ij.extensions;
 
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -27,6 +28,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.ResolveScopeEnlarger;
 import com.intellij.psi.search.GlobalSearchScope;
+import java.util.Map;
 import java.util.Set;
 
 import com.intellij.psi.search.SearchScope;
@@ -48,26 +50,39 @@ public class ManResolveScopeProvider extends ResolveScopeEnlarger
   @Override
   public SearchScope getAdditionalResolveScope( @NotNull VirtualFile file, Project project )
   {
-    if( !ManProject.isManifoldInUse( project ) || !file.isValid() )
+    if( project.isDisposed() || !ManProject.isManifoldInUse( project ) || !file.isValid() )
     {
       return null;
     }
 
     ManProject manProject = ManProject.manProjectFrom( project );
+    if( manProject == null )
+    {
+      return null;
+    }
+    Map<Module, ManModule> modules = manProject.getModules();
+    if( modules == null || modules.isEmpty() )
+    {
+      return null;
+    }
     PsiFile psiFile = PsiManager.getInstance( project ).findFile( file );
+    if( psiFile == null || psiFile.getProject() != project )
+    {
+      return null;
+    }
     GlobalSearchScope unionScope = null;
     if( psiFile instanceof PsiClassOwner )
     {
       PsiClassOwner classFile = (PsiClassOwner)psiFile;
       String fqn = classFile.getPackageName() + '.' + FileUtil.getNameWithoutExtension( classFile.getName() );
-      for( ManModule module : manProject.getModules().values() )
+      for( ManModule module : modules.values() )
       {
         unionScope = addScopeIfExtended( fqn, unionScope, module );
       }
     }
     else
     {
-      for( ManModule module : manProject.getModules().values() )
+      for( ManModule module : modules.values() )
       {
         String[] fqns = module.getTypesForFile( manProject.getFileSystem().getIFile( file ) );
         for( String fqn: fqns )
@@ -83,15 +98,29 @@ public class ManResolveScopeProvider extends ResolveScopeEnlarger
   {
     if( isTypeExtendedInModule( fqn, module ) )
     {
-      GlobalSearchScope scope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope( module.getIjModule() );
+      Module ijModule = module.getIjModule();
+      if( ijModule == null || ijModule.isDisposed() )
+      {
+        return unionScope;
+      }
+
+      GlobalSearchScope scope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope( ijModule );
+      if( scope.getProject() == null )
+      {
+        return unionScope;
+      }
       if( unionScope == null )
       {
         unionScope = scope;
       }
       else
       {
+        if( unionScope.getProject() != scope.getProject() )
+        {
+          return unionScope;
+        }
         // avoid redundant union when the module is already covered by current union scope
-        if( !unionScope.isSearchInModuleContent( module.getIjModule() ) )
+        if( !unionScope.isSearchInModuleContent( ijModule ) )
         {
           unionScope = unionScope.union( scope );
         }


### PR DESCRIPTION
Should fix #95 

### Possible cause
```java
// ManResolveScopeProvider.java
private GlobalSearchScope addScopeIfExtended( String fqn, GlobalSearchScope unionScope, ManModule module )
{
  if( isTypeExtendedInModule( fqn, module ) )
  {
    GlobalSearchScope scope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope( module.getIjModule() );
    if( unionScope == null )
    {
      unionScope = scope;
    }
    else
    {
      if( !scope.isSearchInModuleContent( module.getIjModule() ) )
      {
        unionScope = unionScope.union( scope );
      }
    }
  }
  return unionScope;
}
```

After research by AI, it suggested the root cause to be `scope.isSearchInModuleContent(module)` being always `true` thus `unionScope = unionScope.union(scope)` will never be executed, causing type resolution to fall in incorrect scopes.


### Proposed fix
```java
- if( !scope.isSearchInModuleContent( module.getIjModule() ) )
+ if( !unionScope.isSearchInModuleContent( module.getIjModule() ) )
```

Note that I am not familiar with IDEA plugins. This conclusion is proposed by AI. I've test locally and it is able to fix the bug. Please do a second check before merging.